### PR TITLE
fix(deps): upgrade commons-fileupload 1.3.1 → 1.6.0 (6 CVEs fixed)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
 	        <dependency>
 		    <groupId>commons-fileupload</groupId>
 		    <artifactId>commons-fileupload</artifactId>
-		    <version>1.3.1</version>
+		    <version>1.6.0</version>
 		</dependency>
 		 <!-- Memcached Dependency -->
 		<dependency>


### PR DESCRIPTION
## Summary

Upgrades `commons-fileupload:commons-fileupload` from **1.3.1** to **1.6.0** to remediate 6 vulnerability findings identified by Endor Labs.

## Endor Labs UIA Evidence

| Field | Value |
|---|---|
| UIA UUID | `69f189526c5125ce901fd7c3` |
| Upgrade Risk | **low** |
| CIA Status | **no breaking changes** |
| Findings Fixed | **6** (1 Critical, 4 High, 1 Medium) |
| Findings Introduced | **0** |
| Hard Conflicts | **0** |
| Score | 8/10 |
| `is_best` | ✅ |

## Vulnerabilities Fixed

| Severity | Advisory | Description |
|---|---|---|
| **Critical** | GHSA-7x9j-7223-rg5m | Improper Access Control in commons-fileupload |
| **High** | GHSA-fvm3-cfvj-gxqq | High severity vulnerability in commons-fileupload |
| **High** | GHSA-hfrx-6qgj-fp6c | Apache Commons FileUpload denial of service |
| **High** | GHSA-vv7r-c36w-3prj | FileUpload DoS via part headers |
| **High** | GHSA-78wr-2p64-hpwj | Commons IO: DoS on untrusted input to XmlStreamReader |
| **Medium** | GHSA-gwrp-pvrq-jmwv | Path Traversal and Improper Input Validation in Apache Commons IO |

## Compatibility Analysis

- **Same major version**: 1.3.1 → 1.6.0 (no major-version API break)
- **Source usage**: `FileUploadController` uses Spring's `MultipartFile` abstraction only. No direct imports of `commons-fileupload` APIs (`DiskFileItemFactory`, `ServletFileUpload`, `FileItem`) were found in source.
- **5 minor transitive conflicts**: pre-existing transitive version mediation conflicts (commons-io, javax.servlet, junit) — Maven resolves these via nearest-declaration rule; all are pre-existing in the baseline and not introduced by this change.

## Validation

`mvn dependency:resolve` completed with **BUILD SUCCESS** confirming `commons-fileupload:1.6.0` resolves cleanly in the local POM.

## Manifest Change

```
pom.xml: commons-fileupload:commons-fileupload 1.3.1 → 1.6.0
```

## Test Plan

- [ ] `mvn dependency:resolve` — verifies Maven resolves new version (already passed locally)
- [ ] `mvn package -DskipTests` — verifies project compiles with upgraded dependency
- [ ] `mvn test` — verifies no test regressions
- [ ] Manual smoke-test of `/upload` and `/uploadFile` endpoints (multipart upload)

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code) + Endor Labs SCA Remediation Agent