### PR TITLE
🔴 Critical/High: Fix 3 AI SAST findings (Tomcat privileged context, path traversal, password logging)

### DIFF
--- a/files/context.xml
+++ b/files/context.xml
@@ -15,10 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<Context antiResourceLocking="false" privileged="true" >
-<!--
-  <Valve className="org.apache.catalina.valves.RemoteAddrValve"
-         allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1" />
+<Context antiResourceLocking="false" privileged="false" >
   <Manager sessionAttributeValueClassNameFilter="java\.lang\.(?:Boolean|Integer|Long|Number|String)|org\.apache\.catalina\.filters\.CsrfPreventionFilter\$LruCache(?:\$1)?|java\.util\.(?:Linked)?HashMap"/>
--->
 </Context>

--- a/src/main/java/com/visualpathit/account/controller/FileUploadController.java
+++ b/src/main/java/com/visualpathit/account/controller/FileUploadController.java
@@ -3,6 +3,7 @@ package com.visualpathit.account.controller;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -38,21 +39,31 @@ public class FileUploadController {
 	String uploadFileHandler(@RequestParam("name") String name,@RequestParam("userName") String userName,
 			@RequestParam("file") MultipartFile file) {
 		
-		System.out.println("Called the upload file :::" );
+		logger.info("Called the upload file");
 		if (!file.isEmpty()) {
 			try {
+				// Reject names containing path separators or traversal sequences to
+				// prevent writing outside the intended upload directory.
+				if (name == null || name.isEmpty() || name.contains("/") || name.contains("\\")
+						|| name.contains("..") || !name.matches("[A-Za-z0-9_\\-]+")) {
+					return "Upload rejected: invalid file name.";
+				}
+
 				byte[] bytes = file.getBytes();
 
 				// Creating the directory to store file
 				String rootPath = System.getProperty("catalina.home");
-				System.out.println("Path ::::" +rootPath);
 				File dir = new File(rootPath + File.separator + "tmpFiles");
 				if (!dir.exists())
 					dir.mkdirs();
 
-				// Create the file on server
-				File serverFile = new File(dir.getAbsolutePath()
-						+ File.separator + name+".png");
+				// Canonicalize the target path and confirm it stays inside the upload directory.
+				File serverFile = new File(dir.getAbsolutePath() + File.separator + name + ".png");
+				Path canonicalDir = dir.toPath().toRealPath();
+				Path canonicalFile = serverFile.getCanonicalFile().toPath();
+				if (!canonicalFile.startsWith(canonicalDir)) {
+					return "Upload rejected: path traversal detected.";
+				}
 				//image saving 
 				User user = userService.findByUsername(userName);
 				user.setProfileImg(name +".png");

--- a/src/main/java/com/visualpathit/account/controller/UserController.java
+++ b/src/main/java/com/visualpathit/account/controller/UserController.java
@@ -48,7 +48,6 @@ public class UserController {
         if (bindingResult.hasErrors()) {
             return "registration";
         }
-        System.out.println("User PWD:"+userForm.getPassword());
         userService.save(userForm);
 
         securityService.autologin(userForm.getUsername(), userForm.getPasswordConfirm());


### PR DESCRIPTION
## 🛡️ Endor Labs AURI Security Fix: 3 AI SAST Findings (1 Critical, 2 High)

<!-- endor-auri-metadata
finding_uuids: ["6a0718df679f17077bd27151","6a0718df03914e790f1f175f","6a0718df679f17077bd2714b"]
project_uuid: 69f187cad6831ed647d2888b
namespace: auri
source_sha: 2bc5cfbadfb1156acaa0f703386e6d22b2c73c5f
-->

This PR remediates three AI SAST findings identified by Endor Labs on the `main` branch at commit `2bc5cfb`. All three are confirmed TRUE_POSITIVE with full data-flow evidence. The build compiles cleanly and all 9 existing tests pass after the changes.

---

### 🔧 What changed

**Finding 1 — CRITICAL | Tomcat Privileged Context Misconfiguration**
- **Rule/CWE:** Privileged container context / CWE-250 (Execution with Unnecessary Privileges)
- **Location:** `files/context.xml` line 18
- **Endor finding UUID:** `6a0718df679f17077bd27151`
- **Fix:** Changed `privileged="true"` to `privileged="false"` in the `<Context>` element. Also enabled the previously commented-out `sessionAttributeValueClassNameFilter` on the `<Manager>` element, which restricts deserialization of session attributes to a safe allowlist of types.
- **Why it matters:** A Tomcat context marked `privileged="true"` lets the webapp access internal Tomcat management servlets and resources. Any app-layer exploit (e.g., deserialization RCE) would immediately escalate to container scope — enabling cross-application data access, configuration tampering, and broader disruption. The `RemoteAddrValve` and `sessionAttributeValueClassNameFilter` were also disabled (commented out), leaving the context with no compensating controls.

**Finding 2 — HIGH | Path Traversal in File Upload (CWE-22)**
- **Rule/CWE:** CWE-22 Path Traversal
- **Location:** `src/main/java/com/visualpathit/account/controller/FileUploadController.java` lines 38–65
- **Endor finding UUID:** `6a0718df03914e790f1f175f`
- **Fix:** Added two layers of defense before constructing the server-side file path:
  1. Allowlist validation — the `name` parameter is rejected unless it matches `[A-Za-z0-9_\-]+`, blocking directory separators, dot-dot sequences, and other shell-special characters.
  2. Canonical path check — after constructing the `File` object, the resolved canonical path is verified to start with the canonical upload directory path, providing a backstop against any edge-case traversal that slips past the regex.
  - Also replaced `System.out.println` debug output with the existing SLF4J logger.
- **Why it matters:** The original code concatenated the user-supplied `name` request parameter directly into a `File` path and wrote to it via `FileOutputStream`. An attacker could supply `name=../../../webapps/ROOT/shell` to write arbitrary content (as a `.png` file) to locations outside `tmpFiles`, enabling web content defacement or overwriting operational files.

**Finding 3 — HIGH | Plaintext Password Written to stdout (CWE-532)**
- **Rule/CWE:** CWE-532 Insertion of Sensitive Information into Log File
- **Location:** `src/main/java/com/visualpathit/account/controller/UserController.java` line 51
- **Endor finding UUID:** `6a0718df679f17077bd2714b`
- **Fix:** Removed the `System.out.println("User PWD:"+userForm.getPassword())` statement from the POST `/registration` handler. The password is already protected at rest — `UserServiceImpl` hashes it with BCrypt before persistence. The debug line served no production purpose and exposed plaintext credentials in application logs.
- **Why it matters:** Anyone with access to application stdout (log aggregation, container logs, developer consoles, or an attacker who compromises logging infrastructure) can recover users' plaintext passwords, enabling direct account takeover and secondary attacks via password reuse.

---

### 🔎 Evidence provided by AURI

| # | Severity | Finding UUID | Classification | Score |
|---|----------|-------------|---------------|-------|
| 1 | CRITICAL | `6a0718df679f17077bd27151` | TRUE_POSITIVE | 17/19 |
| 2 | HIGH | `6a0718df03914e790f1f175f` | TRUE_POSITIVE | 14/19 |
| 3 | HIGH | `6a0718df679f17077bd2714b` | TRUE_POSITIVE | 12/19 |

All six Verification Scorecard criteria (V1–V6) were CONFIRMED or N/A for each finding. Source fetched at pinned SHA `2bc5cfbadfb1156acaa0f703386e6d22b2c73c5f`.

---

### ✅ Review checklist

- [ ] `files/context.xml`: confirm `privileged="false"` is correct for this application (not a Tomcat manager app)
- [ ] `files/context.xml`: confirm `sessionAttributeValueClassNameFilter` allowlist does not block any session attribute types used by this app
- [ ] `FileUploadController.java`: confirm the `[A-Za-z0-9_\-]+` filename allowlist covers all legitimate upload names used in production
- [ ] `FileUploadController.java`: confirm the canonical path guard handles the case where `tmpFiles` does not yet exist at startup (the `dir.mkdirs()` call runs before `toRealPath()`)
- [ ] `UserController.java`: confirm no other debug or monitoring tools depend on that stdout line
- [ ] Run `mvn test` locally — 9/9 tests pass on this branch

### 📝 Need an exception instead?

If any finding cannot be remediated immediately, open an Endor Labs exception request referencing the finding UUID and this PR for AppSec review.

<details>
<summary>📎 Finding details</summary>

| Field | Finding 1 | Finding 2 | Finding 3 |
|-------|-----------|-----------|-----------|
| UUID | `6a0718df679f17077bd27151` | `6a0718df03914e790f1f175f` | `6a0718df679f17077bd2714b` |
| Severity | CRITICAL | HIGH | HIGH |
| File | `files/context.xml:18` | `FileUploadController.java:38-65` | `UserController.java:51` |
| CWE class | Unnecessary Privileges | Path Traversal (CWE-22) | Sensitive Info in Logs (CWE-532) |
| Classification | TRUE_POSITIVE | TRUE_POSITIVE | TRUE_POSITIVE |
| Endor project | `endor-matt/java-ewok` (`69f187cad6831ed647d2888b`) | same | same |
| Namespace | `auri` | `auri` | `auri` |
| Source SHA | `2bc5cfb` | `2bc5cfb` | `2bc5cfb` |

</details>

_Generated by AURI Security Agent (Endor Labs) — findings sourced from Endor AI SAST on `main` at `2bc5cfbadfb1156acaa0f703386e6d22b2c73c5f`._